### PR TITLE
Fix GitHub Pages deployment configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,18 +3,24 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react()
-  ],
-  base: "/data-driven-arena-insights/",
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  // Determine if we're in production mode
+  const isProd = mode === 'production';
+  
+  return {
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-}));
+    plugins: [
+      react()
+    ],
+    // Use the correct base path depending on environment
+    base: isProd ? "/edinsights-web/" : "/",
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- Improved Vite configuration to properly handle base paths for GitHub Pages
- Added environment-aware configuration that uses '/' for local development and '/edinsights-web/' for production
- Preserves existing GitHub Pages deployment setup using gh-pages package

## Test plan
- Verify the app builds correctly with 'npm run build'
- Verify the app runs correctly locally with 'npm run dev'
- Once merged, verify that the deployed site works correctly on GitHub Pages

Fixes #1